### PR TITLE
add python bindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ js-debug:
 js:
 	emcc $(EMCC_FLAGS) -O2 -g0 jsbindings.cc -o score_estimator.js
 
+so:
+	$(CXX) $(CXXFLAGS) jsbindings.cc -fPIC --shared -o score_estimator.so
+
 dist:
 	rm OGSScoreEstimator-*.js
 	rm OGSScoreEstimator-*.wasm

--- a/ogs_estimator.py
+++ b/ogs_estimator.py
@@ -1,0 +1,35 @@
+from typing import List
+import ctypes
+
+_estimator_so = ctypes.cdll.LoadLibrary('./score_estimator.so')
+
+# Color.h
+EMPTY = 0
+BLACK = 1
+WHITE = -1
+
+def estimate(width, height, data, player_to_move, trials, tolerance):
+  """Estimate the score and area using the OGS score estimator.
+
+  The `data` argument must be a `height` * `width` iterable indicating
+  where player stones are.
+
+  Return value is the difference between black score and white score
+  (positive means back has more on the board).
+
+  The `data` argument is modified in-place and will indicate the player
+  that the position.
+  """
+  arr = ((width * height) * ctypes.c_int)()
+  for i, v in enumerate(data):
+    arr[i] = v
+  score = _estimator_so.estimate(
+      width, height, arr, player_to_move, trials,
+      ctypes.c_float(tolerance)
+  )
+  data[:] = arr
+  return score
+estimate.__annotations__ = {
+    'width': int, 'height': int, 'data': List[int], 'player_to_move': int,
+    'trials': int, 'tolerance': float, 'return': int,
+}


### PR DESCRIPTION
I'm using the score-estimator on the bots I run on OGS to confirm they are good to pass (or resign) and for training data (extracting the probable player/opponent area from SGF final state).

It took me a bit of tinkering to get the ctypes bindings work so this might save someone a bit of time.